### PR TITLE
퍼즐을 랜덤하게 섞기

### DIFF
--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -1,4 +1,4 @@
-import React, { useReducer, useContext } from "react";
+import React, { useState, useReducer, useContext } from "react";
 import styled from "styled-components";
 import "../commons/common.css";
 //import grid from "../../public/grid.png";
@@ -100,6 +100,9 @@ const Buttons = () => {
     src: null,
   });
 
+  const [randomColIdx, setColIdx] = useState([]);
+  const [randomRowIdx, setRowIdx] = useState([]);
+
   const uploadImg = () => {
     const input = document.querySelector("#input");
     input.click();
@@ -126,11 +129,25 @@ const Buttons = () => {
     reader.readAsDataURL(file); //파일을 읽는 메서드
   };
 
+  //인터넷에서 찾음.
+  const selectIndex = (number) => {
+    let randomIndexArray = [];
+    let i = 0;
+    for (i = 0; i < number; i++) {
+      let randomNum = Math.floor(Math.random() * number);
+      if (randomIndexArray.indexOf(randomNum) === -1) {
+        randomIndexArray.push(randomNum);
+      } else {
+        i--;
+      }
+    }
+    return randomIndexArray;
+  };
+
   const makePuzzle = () => {
     const img = document.getElementById("photoImg");
     //console.log(img.width, img.height);
 
-    //여기서만 해도 되는지는 좀 의문이긴 해요.
     imgDispatch({
       type: "imgInfo",
       payload: { width: img.width, height: img.height, src: img.src },
@@ -174,14 +191,8 @@ const Buttons = () => {
   };
 
   const confirmPuzzle = () => {
-    //console.log(imgInfo.width, imgInfo.height);
-
     document.querySelector("#puzzlePlateWrap").className = "";
 
-    //확정버튼
-    //조절 버튼
-    //퍼즐 변환버튼
-    //원래 있던 이미지
     const hideIdList = [
       "imgUploadBtnWrap",
       "puzzleMakeBtnWrap",
@@ -193,6 +204,9 @@ const Buttons = () => {
     hideIdList.forEach((id) => {
       document.getElementById(id).classList.add("hidden");
     });
+
+    setColIdx(selectIndex(frameValues.column));
+    setRowIdx(selectIndex(frameValues.row));
   };
 
   return (
@@ -228,7 +242,10 @@ const Buttons = () => {
       <PuzzleFrameContext.Provider value={{ frameValues, dispatch }}>
         <PuzzleImageContext.Provider value={{ imgInfo, imgDispatch }}>
           <div id="puzzlePlateWrap" className="hidden">
-            <PuzzlePlate></PuzzlePlate>
+            <PuzzlePlate
+              randomColIdx={randomColIdx}
+              randomRowIdx={randomRowIdx}
+            ></PuzzlePlate>
           </div>
         </PuzzleImageContext.Provider>
       </PuzzleFrameContext.Provider>

--- a/src/components/FrameSettingButtons.js
+++ b/src/components/FrameSettingButtons.js
@@ -90,7 +90,6 @@ const RowDownBtn = styled.div`
 `;
 
 const FrameSettingButtons = () => {
-  //const [frameValues, setFrameValues] = useState([3, 3]);
   const { frameValues, dispatch } = useContext(PuzzleFrameContext);
 
   const changeGrid = (col, row) => {
@@ -99,9 +98,8 @@ const FrameSettingButtons = () => {
     const img = document.getElementById("photoImg");
 
     const puzzleGrid = document.getElementById("photoGrid");
-    //puzzleGrid.classList.remove("hidden");
     puzzleGrid.style.width = `${img.width}px`;
-    //puzzleGrid.src = grids.
+
     let src;
     if (col === 3) {
       if (row === 3) src = grid3x3;
@@ -121,8 +119,9 @@ const FrameSettingButtons = () => {
   };
 
   const columnDown = () => {
-    if (frameValues.column <= 3) return;
-    //setFrameValues([frameValues.column - 1, frameValues.row);
+    if (frameValues.column <= 3) {
+      return;
+    }
 
     changeGrid(frameValues.column - 1, frameValues.row);
 
@@ -135,8 +134,8 @@ const FrameSettingButtons = () => {
   const columnUp = () => {
     if (frameValues.column >= 5) {
       return;
-      //   setFrameValues([frameValues[0] + 1, frameValues[1]]);
     }
+
     changeGrid(frameValues.column + 1, frameValues.row);
     dispatch({
       type: "frameValue",
@@ -150,8 +149,8 @@ const FrameSettingButtons = () => {
   const rowDown = () => {
     if (frameValues.row <= 3) {
       return;
-      //   setFrameValues([frameValues[0], frameValues[1] - 1]);
     }
+
     changeGrid(frameValues.column, frameValues.row - 1);
     dispatch({
       type: "frameValue",
@@ -164,7 +163,6 @@ const FrameSettingButtons = () => {
 
   const rowUp = () => {
     if (frameValues.row >= 5) {
-      //   setFrameValues([frameValues[0], frameValues[1] + 1]);
       return;
     }
     changeGrid(frameValues.column, frameValues.row + 1);

--- a/src/components/PuzzlePlate.js
+++ b/src/components/PuzzlePlate.js
@@ -4,6 +4,21 @@ import "../commons/common.css";
 import doll from "../../public/doll.jpg";
 import { PuzzleFrameContext, PuzzleImageContext } from "../components/Buttons";
 
+const Middle = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const WrapDiv = styled.div`
+  margin: 10px;
+`;
+
+const PuzzlePieceWrap = styled.div`
+  background-color: navy;
+  width: 1000px;
+  height: 150px;
+`;
+
 const PuzzlePlateDiv = styled.div`
   position: relative;
 
@@ -31,11 +46,9 @@ const PuzzleWrap = styled.div`
   display: flex;
 `;
 
-const PuzzlePlate = () => {
-  const { frameValues, dispatch } = useContext(PuzzleFrameContext);
-  const { imgInfo, imgDispatch } = useContext(PuzzleImageContext);
-  //console.log(frameValues, imgInfo);
-
+const PuzzlePlate = ({ randomColIdx, randomRowIdx }) => {
+  const { frameValues } = useContext(PuzzleFrameContext);
+  const { imgInfo } = useContext(PuzzleImageContext);
   const [draggingPuzzle, setDraggingPuzzle] = useState(null);
 
   const dragStart = (e) => {
@@ -79,28 +92,74 @@ const PuzzlePlate = () => {
     htmlStr += tmpHtmlStr;
   }*/
 
+  //
+
   return (
     <>
-      {[...Array(frameValues.row)].map((r, rindex) => {
-        return (
-          <PuzzleWrap key={`puzzleWrap${rindex}`}>
-            {[...Array(frameValues.column)].map((c, cindex) => {
-              return (
-                <PuzzlePlateDiv
-                  key={`puzzlePlate${rindex * frameValues.column + cindex}`}
-                  onDragOver={dragOver}
-                  onDrop={drop}
-                  onDragLeave={dragLeave}
-                  width={imgInfo.width / frameValues.column}
-                  height={imgInfo.height / frameValues.row}
-                ></PuzzlePlateDiv>
-              );
-            })}
-          </PuzzleWrap>
-        );
-      })}
+      <Middle>
+        <WrapDiv>
+          {[...Array(frameValues.row)].map((r, rindex) => {
+            return (
+              <PuzzleWrap key={`puzzleWrap${rindex}`}>
+                {[...Array(frameValues.column)].map((c, cindex) => {
+                  return (
+                    <PuzzlePlateDiv
+                      key={`puzzlePlate${rindex * frameValues.column + cindex}`}
+                      onDragOver={dragOver}
+                      onDrop={drop}
+                      onDragLeave={dragLeave}
+                      width={imgInfo.width / frameValues.column}
+                      height={imgInfo.height / frameValues.row}
+                    ></PuzzlePlateDiv>
+                  );
+                })}
+              </PuzzleWrap>
+            );
+          })}
+        </WrapDiv>
 
-      <PuzzleWrap>
+        <WrapDiv>
+          {[...Array(frameValues.row)].map((r, rindex) => {
+            return (
+              <PuzzleWrap key={`puzzleWrap${rindex}`}>
+                {[...Array(frameValues.column)].map((c, cindex) => {
+                  return (
+                    <PuzzlePlateDiv
+                      key={`puzzlePlate${rindex * frameValues.column + cindex}`}
+                      onDragOver={dragOver}
+                      onDrop={drop}
+                      onDragLeave={dragLeave}
+                      width={imgInfo.width / frameValues.column}
+                      height={imgInfo.height / frameValues.row}
+                    >
+                      <PuzzleDiv
+                        key={`puzzle${cindex * frameValues.row + rindex}`}
+                        draggable="true"
+                        onDragStart={dragStart}
+                        onDragEnd={dragEnd}
+                        width={imgInfo.width / frameValues.column}
+                        height={imgInfo.height / frameValues.row}
+                        src={imgInfo.src}
+                        bwidth={imgInfo.width}
+                        bheight={imgInfo.height}
+                        bpx={
+                          (randomColIdx[cindex] / (frameValues.column - 1)) *
+                          100
+                        }
+                        bpy={
+                          (randomRowIdx[rindex] / (frameValues.row - 1)) * 100
+                        }
+                      ></PuzzleDiv>
+                    </PuzzlePlateDiv>
+                  );
+                })}
+              </PuzzleWrap>
+            );
+          })}
+        </WrapDiv>
+      </Middle>
+
+      {/* <PuzzleWrap>
         {[...Array(frameValues.row)].map((r, rindex) => {
           return (
             <>
@@ -124,7 +183,7 @@ const PuzzlePlate = () => {
             </>
           );
         })}
-      </PuzzleWrap>
+      </PuzzleWrap> */}
     </>
   );
 };


### PR DESCRIPTION
## 📕 제목
퍼즐을 랜덤하게 섞기
관련이슈 #8 , #9 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역
![퍼즐랜덤](https://user-images.githubusercontent.com/35261724/104430614-41c33900-55ca-11eb-9c2c-be298864733e.gif)

- [x] - 확정 버튼을 누르면 오른쪽에 기존 이미지와 동일한 크기의 공간에 랜덤하게 배치된 퍼즐이 나타난다.

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
- 랜덤 함수는 인터넷에서 찾아 사용했다.
- width가 긴 이미지에 대해서는 스크롤이 생기고 불편해지는 문제가 있다.
